### PR TITLE
Pre post build patch save

### DIFF
--- a/bin/postbuild-linux.sh
+++ b/bin/postbuild-linux.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+save_patch_dir="./dist/linux-unpacked/patches/"
+tmp_dir="/tmp/.silvia_patches"
+
+if [ -d $tmp_dir ] ; then
+        echo "Restoring patches ..."
+        mkdir -p $save_patch_dir
+        for f in $tmp_dir/* ; do
+                cp -a $f $save_patch_dir
+        done
+fi
+
+rm -rf $tmp_dir

--- a/bin/prebuild-linux.sh
+++ b/bin/prebuild-linux.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+save_patch_dir="./dist/linux-unpacked/patches/"
+tmp_dir="/tmp/.silvia_patches"
+
+if [ -d $save_patch_dir ] ; then
+        echo "Stashing patches for saving ..."
+        if [ ! -d $tmp_dir ] ; then
+                mkdir -p $tmp_dir
+        fi
+        for f in $save_patch_dir/* ; do
+                cp -a $f $tmp_dir
+        done
+fi

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build": "electron-builder --win --mac --linux",
     "build-win": "electron-builder --win",
     "build-mac": "electron-builder --mac", 
+    "prebuild-linux": "./bin/prebuild-linux.sh",
     "build-linux": "electron-builder --linux",
+    "postbuild-linux": "./bin/postbuild-linux.sh",
     "build-all": "electron-builder --win --mac --linux"
   },
   "keywords": [
@@ -45,7 +47,8 @@
       "!node_modules",
       "!dist",
       "!*.md",
-      "!.git*"
+      "!.git*",
+      "!bin"
     ],
     "win": {
       "target": {


### PR DESCRIPTION
This adjustment makes it so patches saved in the dist/linux-unpacked/patches directory are copied off to /tmp with the prebuild-linux script, then the build runs (which wipes out the patch directory), and then in postbuild-linux, the patches are copied back in to dist/linux-unpacked/patches.

Semantics of the copy actions/behavior could change as need be, but this is the general idea. 